### PR TITLE
feat(clickhouse): Arrow-native transport through the Flight server (REQ-986)

### DIFF
--- a/provisa/federation/clickhouse_backend.py
+++ b/provisa/federation/clickhouse_backend.py
@@ -31,3 +31,15 @@ class ClickHouseBackend(NativeEngineBackend):
             return ClickHouseFederationRuntime.from_url(url)
         # No URL configured → embedded chdb (in-process, no server).
         return ClickHouseFederationRuntime.embedded()
+
+    # -- engine-specific Arrow transports (REQ-986) ----------------------------
+    # ClickHouse honors its declared ARROW / ARROW_STREAM capabilities: the runtime returns native
+    # Arrow (query_arrow over HTTP, chdb ArrowStream) with no row materialization, mirroring
+    # TrinoBackend.execute_arrow / execute_stream. The SQL is already ClickHouse-dialect (transpiled
+    # by the backend seam, like execute_sync). The native-TCP backend has no Arrow format and raises.
+
+    def execute_arrow(self, state: Any, sql: str, params: list | None = None) -> Any:
+        return self._runtime_for(state).run_arrow(sql)
+
+    def execute_stream(self, state: Any, sql: str, params: list | None = None) -> Any:
+        return self._runtime_for(state).run_arrow_stream(sql)

--- a/provisa/federation/clickhouse_runtime.py
+++ b/provisa/federation/clickhouse_runtime.py
@@ -41,10 +41,15 @@ a live EngineRuntime dispatch calls; routing/HTTP wiring is separate — mirrors
 
 from __future__ import annotations
 
-from typing import Any, Protocol
+from typing import TYPE_CHECKING, Any, Protocol, cast
 from urllib.parse import urlparse
 
 from provisa.executor.result import QueryResult
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    import pyarrow as pa
 from provisa.federation.engine import build_clickhouse_engine
 from provisa.federation.runtime_support import columns_from_describe, run_async
 from provisa.transpiler.transpile import transpile
@@ -59,6 +64,14 @@ class _CHBackend(Protocol):
 
     def query(self, sql: str) -> tuple[list[tuple], list[str]]:
         """Run a query, returning ``(rows, column_names)``."""
+        ...
+
+    def query_arrow(self, sql: str) -> pa.Table:
+        """Run a query, returning a materialized Arrow table (REQ-986)."""
+        ...
+
+    def query_arrow_stream(self, sql: str) -> tuple[pa.Schema, Iterator[pa.RecordBatch]]:
+        """Run a query, returning ``(schema, lazy RecordBatch iterator)`` (REQ-986)."""
         ...
 
     def close(self) -> None: ...
@@ -81,6 +94,36 @@ class _ServerBackend:
         res = self._client.query(sql)
         return [tuple(r) for r in res.result_rows], list(res.column_names)
 
+    def query_arrow(self, sql: str) -> pa.Table:
+        # clickhouse-connect requests FORMAT Arrow and returns a native pyarrow Table — no row
+        # materialization (REQ-986). use_strings maps ClickHouse String to Arrow utf8, not binary.
+        return self._client.query_arrow(sql, use_strings=True)
+
+    def query_arrow_stream(self, sql: str) -> tuple[pa.Schema, Iterator[pa.RecordBatch]]:
+        # FORMAT ArrowStream: the server streams IPC blocks and clickhouse-connect wraps them in a
+        # StreamContext over a pyarrow RecordBatchStreamReader. The context must stay open for the
+        # lifetime of the iterator, so the generator owns enter/exit (REQ-986).
+        import pyarrow as pa
+
+        stream_ctx = self._client.query_arrow_stream(sql, use_strings=True)
+        reader: Any = stream_ctx.gen  # the pyarrow RecordBatchStreamReader the context wraps
+        schema = reader.schema  # available before consumption; GeneratorStream needs it up front
+        stream_ctx.__enter__()
+
+        def _batches() -> Iterator[pa.RecordBatch]:
+            try:
+                for chunk in stream_ctx:
+                    # clickhouse-connect yields one Arrow object per IPC block — normalize either a
+                    # Table or a RecordBatch to the record batches the Flight stream expects.
+                    if isinstance(chunk, pa.Table):
+                        yield from chunk.to_batches()
+                    else:
+                        yield chunk
+            finally:
+                stream_ctx.__exit__(None, None, None)
+
+        return schema, _batches()
+
     def close(self) -> None:
         self._client.close()
 
@@ -100,8 +143,25 @@ class _NativeBackend:
         self._client.execute(sql)
 
     def query(self, sql: str) -> tuple[list[tuple], list[str]]:
-        rows, cols = self._client.execute(sql, with_column_types=True)
+        # with_column_types=True → (rows, [(name, type), ...]); the driver stub types execute() as a
+        # union (row-count int for DDL), so narrow it explicitly.
+        rows, cols = cast(
+            "tuple[list[tuple], list[tuple[str, str]]]",
+            self._client.execute(sql, with_column_types=True),
+        )
         return [tuple(r) for r in rows], [c[0] for c in cols]
+
+    def query_arrow(self, sql: str) -> pa.Table:
+        raise NotImplementedError(
+            "the ClickHouse native TCP transport (clickhouse-driver) has no Arrow format; "
+            "use clickhouse:// (HTTP) or chdb:// for the Arrow Flight ENGINE path (REQ-986)"
+        )
+
+    def query_arrow_stream(self, sql: str) -> tuple[pa.Schema, Iterator[pa.RecordBatch]]:
+        raise NotImplementedError(
+            "the ClickHouse native TCP transport (clickhouse-driver) has no Arrow format; "
+            "use clickhouse:// (HTTP) or chdb:// for the Arrow Flight ENGINE path (REQ-986)"
+        )
 
     def close(self) -> None:
         self._client.disconnect()
@@ -131,6 +191,36 @@ class _EmbeddedBackend:
         cols = table.column_names
         rows = [tuple(d[c] for c in cols) for d in table.to_pylist()]
         return rows, list(cols)
+
+    def query_arrow(self, sql: str) -> pa.Table:
+        import io
+
+        import pyarrow as pa
+
+        raw = self._session.query(sql, "ArrowStream").bytes()
+        if not raw:
+            return pa.table({})
+        return pa.ipc.open_stream(io.BytesIO(raw)).read_all()
+
+    def query_arrow_stream(self, sql: str) -> tuple[pa.Schema, Iterator[pa.RecordBatch]]:
+        # chdb hands back the whole ArrowStream buffer at once, so this is pseudo-streaming: the
+        # result is already materialized in-process. We still expose it as a batch iterator so the
+        # Flight ARROW_STREAM transport is uniform across backends (REQ-986).
+        import io
+
+        import pyarrow as pa
+
+        raw = self._session.query(sql, "ArrowStream").bytes()
+        if not raw:
+            empty = pa.table({})
+            return empty.schema, iter(())
+        reader = pa.ipc.open_stream(io.BytesIO(raw))
+        schema = reader.schema
+
+        def _batches() -> Iterator[pa.RecordBatch]:
+            yield from reader
+
+        return schema, _batches()
 
     def close(self) -> None:
         self._session.close()
@@ -274,6 +364,16 @@ class ClickHouseFederationRuntime:  # REQ-825, REQ-840, REQ-909, REQ-912
 
     async def run(self, sql: str, params: list | None = None) -> QueryResult:
         return await run_async(self.run_sync, sql, params)
+
+    def run_arrow(self, sql: str) -> pa.Table:
+        """Execute ClickHouse-dialect SQL and return a native Arrow table — the ENGINE ARROW terminal
+        the Flight server calls (REQ-986). Mirrors run_sync but keeps results columnar end-to-end."""
+        return self._backend.query_arrow(sql)
+
+    def run_arrow_stream(self, sql: str) -> tuple[pa.Schema, Iterator[pa.RecordBatch]]:
+        """Execute ClickHouse-dialect SQL and return ``(schema, lazy RecordBatch iterator)`` — the
+        ENGINE ARROW_STREAM terminal for the Flight server (REQ-986)."""
+        return self._backend.query_arrow_stream(sql)
 
     @property
     def connection(self):

--- a/provisa/federation/engine.py
+++ b/provisa/federation/engine.py
@@ -462,8 +462,8 @@ def build_clickhouse_engine() -> FederationEngine:  # REQ-909 OLAP partial feder
         backend_factory=ClickHouseBackend,  # in-process terminal driving ClickHouseFederationRuntime
         default_materialize_store=_platform_db_materialize_default,
         capabilities=frozenset(
-            {EngineCapability.ROWS, EngineCapability.ARROW}
-        ),  # query_arrow (REQ-909)
+            {EngineCapability.ROWS, EngineCapability.ARROW, EngineCapability.ARROW_STREAM}
+        ),  # query_arrow + query_arrow_stream over HTTP / chdb ArrowStream (REQ-909, REQ-986)
     )
 
 

--- a/tests/integration/test_clickhouse_runtime_e2e.py
+++ b/tests/integration/test_clickhouse_runtime_e2e.py
@@ -47,3 +47,57 @@ async def test_clickhouse_runtime_federates_csv_source():
         assert len(rows.rows) == 3
     finally:
         rt.close()
+
+
+async def test_clickhouse_runtime_arrow_transport():
+    """REQ-986: the ENGINE ARROW terminal returns a native pyarrow Table, no row materialization."""
+    import pyarrow as pa
+
+    rt = ClickHouseFederationRuntime.embedded()
+    try:
+        table = rt.run_arrow("SELECT number AS n, toString(number) AS s FROM numbers(5) ORDER BY n")
+        assert isinstance(table, pa.Table)
+        assert table.num_rows == 5
+        assert table.column_names == ["n", "s"]
+        assert table.column("n").to_pylist() == [0, 1, 2, 3, 4]
+    finally:
+        rt.close()
+
+
+async def test_clickhouse_runtime_arrow_stream_transport():
+    """REQ-986: the ENGINE ARROW_STREAM terminal returns (schema, lazy RecordBatch iterator)."""
+    import pyarrow as pa
+
+    rt = ClickHouseFederationRuntime.embedded()
+    try:
+        schema, batches = rt.run_arrow_stream("SELECT number AS n FROM numbers(9) ORDER BY n")
+        assert isinstance(schema, pa.Schema)
+        assert schema.names == ["n"]
+        collected = list(batches)
+        assert all(isinstance(b, pa.RecordBatch) for b in collected)
+        assert sum(b.num_rows for b in collected) == 9
+    finally:
+        rt.close()
+
+
+async def test_clickhouse_backend_arrow_capabilities_wired():
+    """REQ-986: the engine declares ARROW/ARROW_STREAM and the backend honors both."""
+    import pyarrow as pa
+
+    from provisa.federation.clickhouse_backend import ClickHouseBackend
+    from provisa.federation.engine import build_clickhouse_engine
+    from provisa.federation.runtime import EngineCapability
+
+    engine = build_clickhouse_engine()
+    assert EngineCapability.ARROW in engine.capabilities
+    assert EngineCapability.ARROW_STREAM in engine.capabilities
+
+    backend = ClickHouseBackend(engine)
+    state = SimpleNamespace(config=None)
+    table = backend.execute_arrow(state, "SELECT number AS n FROM numbers(3)")
+    assert isinstance(table, pa.Table)
+    assert table.num_rows == 3
+
+    schema, batches = backend.execute_stream(state, "SELECT number AS n FROM numbers(4)")
+    assert schema.names == ["n"]
+    assert sum(b.num_rows for b in batches) == 4


### PR DESCRIPTION
## Summary
Wires ClickHouse to serve columnar Arrow through the Provisa Arrow Flight server, honoring its declared `ARROW` capability and adding `ARROW_STREAM` (REQ-986). Previously the ClickHouse backend collapsed all results to Python row tuples, discarding native Arrow even though the engine advertised the capability.

The Flight server's ENGINE route already dispatched through `execute_engine_arrow` / `execute_engine_stream` — no change needed there. This makes `ClickHouseBackend` actually implement those transports (mirroring `TrinoBackend`).

## Changes
- **engine.py** — `build_clickhouse_engine` declares `ARROW_STREAM` alongside `ROWS, ARROW`.
- **clickhouse_runtime.py** — `query_arrow` / `query_arrow_stream` on the `_CHBackend` seam:
  - `_ServerBackend` (HTTP): native `client.query_arrow()` / `query_arrow_stream()` — true streaming, no row materialization.
  - `_EmbeddedBackend` (chdb): `ArrowStream` bytes → pyarrow Table / batch iterator (pseudo-stream; already in-process).
  - `_NativeBackend` (TCP): raises — clickhouse-driver has no Arrow format; directs callers to HTTP/chdb.
  - `run_arrow` / `run_arrow_stream` runtime terminals.
  - Also fixed a clickhouse-driver `execute()` union-type pyright error via cast.
- **clickhouse_backend.py** — `ClickHouseBackend.execute_arrow` / `execute_stream` delegating to the runtime.
- **tests** — 3 new integration tests (arrow, arrow_stream, backend+capabilities) against embedded chdb.

## Verification
- New arrow tests: 4 passed
- ClickHouse connector unit tests: 16 passed
- pyright: 0 errors (3 source files)
- ruff: clean
- complexity gate: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)